### PR TITLE
Bugfixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,160 @@
+{
+  "name": "usfm-grammar-demo",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "ansi-regex": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+      "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg=="
+    },
+    "ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "requires": {
+        "color-convert": "^2.0.1"
+      }
+    },
+    "cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "requires": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "formidable": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.2.2.tgz",
+      "integrity": "sha512-V8gLm+41I/8kguQ4/o1D3RIHRmhYFG4pnNyonvua+40rqcEmT4+V71yaZ3B457xbbgCsCfjSPi65u/W6vK1U5Q=="
+    },
+    "get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
+    },
+    "is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ=="
+    },
+    "is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="
+    },
+    "jsonschema": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/jsonschema/-/jsonschema-1.4.0.tgz",
+      "integrity": "sha512-/YgW6pRMr6M7C+4o8kS+B/2myEpHCrxO4PEWnqJNBFMjn7EWXqlQ4tGwL6xTHeRplwuZmcAncdvfOad1nT2yMw=="
+    },
+    "ohm-js": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/ohm-js/-/ohm-js-15.4.1.tgz",
+      "integrity": "sha512-ob5b6hnlg6tR73Zxd8ON/MQND36SgEDbKQYrzdDVVyTNa3d3aJ/YyobB7mItJ8YXNTZGgZ/eUiLtfo2CU0uREA==",
+      "requires": {
+        "is-buffer": "^2.0.4",
+        "util-extend": "^1.0.3"
+      }
+    },
+    "require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
+    },
+    "string-width": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.0.tgz",
+      "integrity": "sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==",
+      "requires": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
+      "integrity": "sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==",
+      "requires": {
+        "ansi-regex": "^5.0.0"
+      }
+    },
+    "usfm-grammar": {
+      "version": "2.0.0-beta.9",
+      "resolved": "https://registry.npmjs.org/usfm-grammar/-/usfm-grammar-2.0.0-beta.9.tgz",
+      "integrity": "sha512-LuMXPRRrZwZLoUfjFenVyKTaTP1Ghx6e1lFbup9Q2uNp+U1Un7oMM8aVVCsqv+IkQRhvUH9CaiqBNCwVCGmCeQ==",
+      "requires": {
+        "jsonschema": "^1.4.0",
+        "ohm-js": "^15.3.0",
+        "yargs": "^16.2.0"
+      }
+    },
+    "util-extend": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/util-extend/-/util-extend-1.0.3.tgz",
+      "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
+    },
+    "wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      }
+    },
+    "y18n": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.5.tgz",
+      "integrity": "sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg=="
+    },
+    "yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "requires": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      }
+    },
+    "yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,32 @@
+{
+  "name": "usfm-grammar-demo",
+  "version": "1.0.0",
+  "description": "A simple website to demonstrate usfm-grammar tool",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/kavitharaju/usfm-grammar-demo.git"
+  },
+  "keywords": [
+    "usfm-grammar",
+    "USFM",
+    "parser",
+    "bridgeconn",
+    "bcs",
+    "usfm-parser"
+  ],
+  "author": "kavitharaju",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/kavitharaju/usfm-grammar-demo/issues"
+  },
+  "homepage": "https://github.com/kavitharaju/usfm-grammar-demo#readme",
+  "dependencies": {
+    "formidable": "^1.2.2",
+    "usfm-grammar": "^2.0.0-beta.9"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -30,6 +30,7 @@ http.createServer(function (req, res) {
   switch (req.url) {
 
     case '/':
+      usfm_val = '\\id HAB 45HABGNT92.usfm, Good News Translation, June 2003\n\\c 3\n\\s1 A Prayer of Habakkuk\n\\p\n\\v 1 This is a prayer of the prophet Habakkuk:\n\\b\n\\q1\n\\v 2 O \\nd Lord\\nd*, I have heard of what you have done,\n\\q2 and I am filled with awe.\n\\q1 Now do again in our times\n\\q2 the great deeds you used to do.\n\\q1 Be merciful, even when you are angry.'
       let html_data = eval('`' + html_tmplt + '`');
       res.writeHead(200, { 'Content-Type': 'text/html' })
       res.write(html_data)

--- a/server.js
+++ b/server.js
@@ -31,6 +31,14 @@ http.createServer(function (req, res) {
 
     case '/':
       usfm_val = '\\id HAB 45HABGNT92.usfm, Good News Translation, June 2003\n\\c 3\n\\s1 A Prayer of Habakkuk\n\\p\n\\v 1 This is a prayer of the prophet Habakkuk:\n\\b\n\\q1\n\\v 2 O \\nd Lord\\nd*, I have heard of what you have done,\n\\q2 and I am filled with awe.\n\\q1 Now do again in our times\n\\q2 the great deeds you used to do.\n\\q1 Be merciful, even when you are angry.'
+      json_val = '{}'
+      csv_val = ''
+      tsv_val = ''
+      rhs_error = ''
+      lhs_error = ''
+      selectedTab = 'toJSON'
+      selectedScripture = 'A'
+      selectedType= 'N'
       let html_data = eval('`' + html_tmplt + '`');
       res.writeHead(200, { 'Content-Type': 'text/html' })
       res.write(html_data)

--- a/ui/usfm-grammar.js
+++ b/ui/usfm-grammar.js
@@ -45,12 +45,14 @@ function pageLoad() {
         document.getElementById("box1_error").style.display = 'none';
     } else {
         document.getElementById("box1_error").style.display = 'block';
+        window.scrollTo(0,document.body.scrollHeight);
     }
 
     if (document.getElementById("box2_error_content").innerHTML == '') {
         document.getElementById("box2_error").style.display = 'none';
     } else {
         document.getElementById("box2_error").style.display = 'block';
+        window.scrollTo(0,document.body.scrollHeight);
     }
 }
 


### PR DESCRIPTION
This PR contains two bugfixes
* refresh data and components in UI, on index page reload

*The current behaviour* is, when the server is started, it loads the default USFM example from book of Habakkuk. But once any user uses it the new USFM he has uploaded and the options he has selected for LEVEL and FILTER persists there and when another user accesses the first page these values are shown for him

*It is changed to* reset all values to default options on accessing the index page(root url)

* Auto scroll to Error Message

*The current behaviour* is, when there is a parsing error in USFM or JSON, the error message is shown at the error boxes that appear at the bottom of the page. The input fields of USFM and JSON have fixed height and the error boxes are usually not seen unless we scroll the page down. This leads the user to, not realise he got an error and wonder why the output is empty.

*It is changed to* autoscroll to the bottom of the page when ever an error occurs, so that the user do not fail to see the error boxes that appear at the bottom